### PR TITLE
Fix indentation and add port mapping in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,13 @@ You will need to assign the `marathon-deploy` role to access the `marathon` modu
             container:
                 type: "DOCKER"
                 docker:
-                image: "prom/prometheus:latest"
-                network: "BRIDGE"
-                privileged: false
-                forcePullImage: true
-                portMappings: []
+                  image: "prom/prometheus:latest"
+                  network: "BRIDGE"
+                  privileged: false
+                  forcePullImage: true
+                  portMappings:
+                  - containerPort: 9090
+                    hostPort: 0
             healthChecks: []
             upgradeStrategy:
                 maximumOverCapacity: 0


### PR DESCRIPTION
Indentation is a bug and it won't work without this fix. Port mapping is not required, but useful for testing and as an example - then links from Marathon UI to containers lead actually to Prometheus instead of nowhere.